### PR TITLE
Fixed a crash on Windows at least; changed magic address length numbers ...

### DIFF
--- a/src/dyad.c
+++ b/src/dyad.c
@@ -456,12 +456,13 @@ static void dyad_initAddress(dyad_Stream *stream) {
     }
   }
   if (addr.sas.ss_family == AF_INET6) {
-    stream->address = dyad_realloc(NULL, 46);
-    inet_ntop(AF_INET6, &addr.sai6.sin6_addr, stream->address, 45);
+    stream->address = dyad_realloc(NULL, INET6_ADDRSTRLEN);
+    inet_ntop(AF_INET6, &addr.sai6.sin6_addr, stream->address,
+              INET6_ADDRSTRLEN);
     stream->port = ntohs(addr.sai6.sin6_port);
   } else {
-    stream->address = dyad_realloc(NULL, 16);
-    inet_ntop(AF_INET, &addr.sai.sin_addr, stream->address, 15);
+    stream->address = dyad_realloc(NULL, INET_ADDRSTRLEN);
+    inet_ntop(AF_INET, &addr.sai.sin_addr, stream->address, INET_ADDRSTRLEN);
     stream->port = ntohs(addr.sai.sin_port);
   }
 }


### PR DESCRIPTION
...to #defines

Hey, I experienced a crash on Windows 7 because of these magic numbers. According to this page:
http://pubs.opengroup.org/onlinepubs/009695399/functions/inet_ntop.html
inet_ntop's behavior can be bad if the size parameter is less than INET_ADDRSTRLEN for ipv4, INET6_ADDRSTRLEN for ipv6. So I just stuck those macros in.

I've tested on Windows 7, iOS 7, Mac OSX, and Android 4.4.2 at least. Not that you should trust me!

I'm not sure if you had a reason to use magic numbers instead of macros, maybe they are missing on some setups. I can do some #ifdef logic if that's the case though.

Thanks for this wonderful library, by the way!

Best,
Dan
