### PR TITLE
warning removal

### DIFF
--- a/src/dyad.c
+++ b/src/dyad.c
@@ -7,7 +7,9 @@
 
 #ifdef _WIN32
   #define _WIN32_WINNT 0x501
-  #define _CRT_SECURE_NO_WARNINGS
+  #ifndef _CRT_SECURE_NO_WARNINGS
+    #define _CRT_SECURE_NO_WARNINGS
+  #endif
   #include <winsock2.h>
   #include <ws2tcpip.h>
   #include <windows.h>
@@ -60,7 +62,7 @@
     } else {
       memcpy(&addr.sai.sin_addr, src, sizeof(addr.sai.sin_addr));
     }
-    res = WSAAddressToString(&addr.sa, sizeof(addr), 0, dst, (LPDWORD) &size);
+    res = WSAAddressToStringA(&addr.sa, sizeof(addr), 0, dst, (LPDWORD) &size);
     if (res != 0) return NULL;
     return dst;
   }
@@ -700,8 +702,17 @@ void dyad_update(void) {
   }
 
   /* Init timeout value and do select */
+  #ifdef _MSC_VER
+    #pragma warning(push)
+    /* Disable double to long implicit conversion warning,
+     * because the type of timeval's fields don't agree across platforms */
+    #pragma warning(disable: 4244)
+  #endif
   tv.tv_sec = dyad_updateTimeout;
   tv.tv_usec = (dyad_updateTimeout - tv.tv_sec) * 1e6;
+  #ifdef _MSC_VER
+    #pragma warning(pop)
+  #endif
 
   select(dyad_selectSet.maxfd + 1,
          dyad_selectSet.fds[SELECT_READ],


### PR DESCRIPTION
I like having 0 warnings in a build....

I'm pretty confident with the _CRT_SECURE_NO_WARNINGS guard, which allows for specification of that directive outside, without creating a warning. I'm not sure if the second change can be more elegant.

Tested on Windows and Mac.