### PR TITLE
warning removal

### DIFF
--- a/src/dyad.c
+++ b/src/dyad.c
@@ -45,6 +45,9 @@
   #define close(a) closesocket(a)
   #define getsockopt(a,b,c,d,e) getsockopt((a),(b),(c),(char*)(d),(e))
   #define setsockopt(a,b,c,d,e) setsockopt((a),(b),(c),(char*)(d),(e))
+  #define select(a,b,c,d,e) select((int)(a),(b),(c),(d),(e))
+  #define bind(a,b,c) bind((a),(b),(int)(c))
+  #define connect(a,b,c) connect((a),(b),(int)(c))
 
   #undef  errno
   #define errno WSAGetLastError()


### PR DESCRIPTION
I'm not 100% about other platforms, but this gets rid of some MSVC 64-bit warnings. A quick google suggests that I'm casting these vars to what the function expects, which is happening anyway. This contribution only removes warnings -- the original writer of the code should judge whether the intent matches the implementation. If this code was always correct, this PR is solidifying that position. If this code was always wrong, I guess I'm prompting for a fix.