### PR TITLE
Fixed Windows client streams, C++ compilation and added fast loopback path for Windows

### DIFF
--- a/src/dyad.h
+++ b/src/dyad.h
@@ -98,6 +98,7 @@ int  dyad_getPort(dyad_Stream *stream);
 int  dyad_getBytesSent(dyad_Stream *stream);
 int  dyad_getBytesReceived(dyad_Stream *stream);
 dyad_Socket dyad_getSocket(dyad_Stream *stream);
+int dyad_win32EnableFastLoopbackPath(dyad_Stream *stream);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
- Made client streams work on Windows (AF_UNSPEC => AF_INET)
- Made the source code compilable in C++ mode
- Added fast TCP loopback path for Windows (for Windows Server 2012, Windows 8 and higher)
